### PR TITLE
feat: add dev script, update yaml version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ htmlcov
 build/
 dist/
 .venv/
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.8-alpine
+
+# Define the working directory.
+# Note: There is no code here; it is pulled from the repository by mounting
+# the directory (see `serve.sh`).
+WORKDIR /code
+
+# Install Python packages for this project.
+COPY . /code
+RUN pip install -e .
+
+# Set environment variables.
+ENV FLASK_ENV development
+
+# Expose appropriate ports.
+EXPOSE 4000
+EXPOSE 35729
+
+# Run the development server.
+# Reminder: Use -p with `docker run` to publish ports (see `serve.sh`).
+WORKDIR /code/tests/test_data
+ENTRYPOINT ["aep-site-serve", "."]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ $ pip install --editable .
 $ aep-site-serve /path/to/aep/data/on/your/system
 ```
 
+### Using the docker container
+
+For quick serving, a docker container can also be used, wrapped in
+a convenience script `serve.sh`.
+
+```
+./serve.sh
+```
+
 [dataclasses]: https://docs.python.org/3/library/dataclasses.html
 [jekyll]: https://jekyllrb.com/
 [jinja2]: https://jinja.palletsprojects.com/en/2.11.x/

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+#   This script runs a "development server" from Docker.
+# -----------------------------------------------------------------------------
+
+# Build the image (if and only if it is not already built).
+if [[ "$(docker images -q aep-site 2> /dev/null)" == "" ]]; then
+  if ! docker build -t aep-site . ; then
+    exit $?
+  fi
+fi
+
+# Run the image.
+docker run --rm \
+  -p 4000:4000/tcp -p 4000:4000/udp \
+  -p 35729:35729/tcp -p 35729:35729/udp \
+  --mount type=bind,source="$(pwd)",destination=/code/,readonly \
+  aep-site
+  "$@"

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'pygments==2.13.0',
         'pymdown-extensions==9.7',
         'pyscss==1.4.0',
-        'pyyaml==6.0',
+        'pyyaml==6.0.1',
         'six==1.16.0',
         'types-Markdown==3.4.2.1',
         'types-PyYAML==6.0.12',


### PR DESCRIPTION
Similar to the scripts in aep.dev, adding a docker container workflow (serve.sh) in the site-generator as well.

The yaml version was outdated due to an updated Cython requirement, therefore updating it.