### PR TITLE
fix: remove Google logo.

### DIFF
--- a/aep_site/support/templates/includes/header.html.j2
+++ b/aep_site/support/templates/includes/header.html.j2
@@ -9,7 +9,7 @@
             <a class="glue-header__logo-link" href="{{ site.relative_uri }}/" title="Google">
               <div class="glue-header__logo-container">
                 <svg role="img" aria-hidden="true" class="glue-header__logo-svg">
-                <use xlink:href="{{ site.relative_uri }}/assets/images/glue-icons.svg#google-color-logo"></use>
+                <!--<use xlink:href="{{ site.relative_uri }}/assets/images/glue-icons.svg#google-color-logo"></use>-->
                 </svg>
               </div>
               <p class="glue-header__logo--product">AEPs</p>
@@ -84,7 +84,7 @@
             <a class="glue-header__logo-link" href="{{ site.relative_uri }}/" title="Google">
               <div class="glue-header__logo-container">
                 <svg role="img" aria-hidden="true" class="glue-header__logo-svg">
-                  <use xlink:href="{{ site.relative_uri }}/assets/images/glue-icons.svg#google-color-logo"></use>
+                  <!--<use xlink:href="{{ site.relative_uri }}/assets/images/glue-icons.svg#google-color-logo"></use>-->
                 </svg>
               </div>
               <p class="glue-header__logo--product">AEPs</p>


### PR DESCRIPTION
AEPs are not a Google-sponsored nor endorsed project: we should remove the logo to make that clear.

The logo is commented out rather than removed so we can add a new logo as that is decided.