### PR TITLE
feat: add slug to AEP page

### DIFF
--- a/aep_site/support/scss/imports/aep/nav.scss
+++ b/aep_site/support/scss/imports/aep/nav.scss
@@ -1,6 +1,6 @@
 #aep-nav {
   .nav-item {
-    span.aep-number {
+    span.aep-id {
       display: inline-block;
       min-width: 26px;
       text-align: right;

--- a/aep_site/support/scss/imports/headings.scss
+++ b/aep_site/support/scss/imports/headings.scss
@@ -1,5 +1,6 @@
 // Headers
 .docs-component-main {
+
   h1,
   h2,
   h3,
@@ -25,13 +26,14 @@
       text-decoration: none;
     }
   }
+
   h4 {
     padding-bottom: 5px;
 
-    &.aep-number {
+    &.aep-id {
       line-height: 1em;
 
-      & + h1 {
+      &+h1 {
         margin-top: 0px;
         margin-left: -2px;
       }

--- a/aep_site/support/templates/aep.html.j2
+++ b/aep_site/support/templates/aep.html.j2
@@ -22,6 +22,7 @@ AEP-{{ aep.id }}: {{ aep.title }}
   {# Wikipedia-style info table. -#}
   <table id="aep-summary">
     <tr><th colspan="2">{{ aep.title }}</th></tr>
+    <tr><td>Slug</td><td>{{ aep.slug }}</td></tr>
     <tr><td>Number</td><td>{{ aep.id }}</td></tr>
     {% with permalink = site.base_url + aep.relative_uri -%}
     <tr><td>Permalink</td><td><a href="{{ permalink }}">{{ permalink.lstrip('htps')[3:] }}</a></td></tr>
@@ -55,7 +56,7 @@ AEP-{{ aep.id }}: {{ aep.title }}
     {% include 'includes/breadcrumb.html.j2' %}
   {% endwith -%}
   {% include 'includes/state_banners/' + aep.state + '.html.j2' ignore missing %}
-  <h4 class="aep-number">AEP-{{ aep.id }}</h4>
+  <h4 class="aep-number">{{ aep.slug }} (AEP-{{ aep.id }})</h4>
   {{ aep.content.html }}
   {% include 'includes/footer.html.j2' %}
 </section>

--- a/aep_site/support/templates/aep.html.j2
+++ b/aep_site/support/templates/aep.html.j2
@@ -56,7 +56,7 @@ AEP-{{ aep.id }}: {{ aep.title }}
     {% include 'includes/breadcrumb.html.j2' %}
   {% endwith -%}
   {% include 'includes/state_banners/' + aep.state + '.html.j2' ignore missing %}
-  <h4 class="aep-number">{{ aep.slug }} (AEP-{{ aep.id }})</h4>
+  <h4 class="aep-id">{{ aep.slug }} (AEP-{{ aep.id }})</h4>
   {{ aep.content.html }}
   {% include 'includes/footer.html.j2' %}
 </section>

--- a/aep_site/support/templates/includes/nav.html.j2
+++ b/aep_site/support/templates/includes/nav.html.j2
@@ -18,7 +18,7 @@
       {% for aep in cat.aeps.values() -%}
         <li class="nav-item{% if path.split('/')[-1] == '{:d}'.format(aep.id) %} nav-item-active{% endif %}">
           <a href="{{ site.relative_uri }}/{{ aep.id }}">
-            <span class="aep-number">{{ aep.id }}</span>
+            <span class="aep-id">{{ aep.id }}</span>
             {{ aep.title }}
           </a>
         </li>

--- a/aep_site/support/templates/includes/nav.html.j2
+++ b/aep_site/support/templates/includes/nav.html.j2
@@ -14,7 +14,7 @@
     {# Individual AEPs in this scope. -#}
     <li class="nav-item nav-item-header">AEPs</li>
     {% for cat in site.scopes[scope_code].categories.values() -%}
-      <li class="nav-item">{{ cat.title }}</li>
+      <li class="nav-item"><b>{{ cat.title }}</b></li>
       {% for aep in cat.aeps.values() -%}
         <li class="nav-item{% if path.split('/')[-1] == '{:d}'.format(aep.id) %} nav-item-active{% endif %}">
           <a href="{{ site.relative_uri }}/{{ aep.id }}">


### PR DESCRIPTION
Since we're moving toward slugs as the canonical identifier
rather than aep numbers, making the more prominent on the
AEP page.

Also adding bold to the categories in the navigation to
help better distinguish category vs AEP.