### PR TITLE
Updating Google Tag Manager

### DIFF
--- a/aep_site/support/templates/layouts/base.html.j2
+++ b/aep_site/support/templates/layouts/base.html.j2
@@ -25,17 +25,19 @@
     {% block js -%}
     {% endblock -%}
     {# {% seo %} -- port this #}
-    {# Global site tag (gtag.js) - Google Analytics -#}
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140054909-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-140054909-1');
-    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-NSXMVSDN');</script>
+    <!-- End Google Tag Manager -->
   </head>
   <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NSXMVSDN"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
     {% include 'includes/header.html.j2' %}
     <div class="glue-page">
       {% block main %}


### PR DESCRIPTION
removing the old AIP GTM container and establish an independent analytics property. This addresses #13 .