### PR TITLE
Removing "Google" from link title

### DIFF
--- a/aep_site/support/templates/includes/header.html.j2
+++ b/aep_site/support/templates/includes/header.html.j2
@@ -6,7 +6,7 @@
       <div class="glue-header__container">
         <div class="glue-header__lock-up">
           <div class="glue-header__logo">
-            <a class="glue-header__logo-link" href="{{ site.relative_uri }}/" title="Google">
+            <a class="glue-header__logo-link" href="{{ site.relative_uri }}/" title="Home">
               <div class="glue-header__logo-container">
                 <svg role="img" aria-hidden="true" class="glue-header__logo-svg">
                 <!--<use xlink:href="{{ site.relative_uri }}/assets/images/glue-icons.svg#google-color-logo"></use>-->

--- a/aep_site/support/templates/includes/header.html.j2
+++ b/aep_site/support/templates/includes/header.html.j2
@@ -6,7 +6,7 @@
       <div class="glue-header__container">
         <div class="glue-header__lock-up">
           <div class="glue-header__logo">
-            <a class="glue-header__logo-link" href="{{ site.relative_uri }}/" title="Home">
+            <a class="glue-header__logo-link" href="{{ site.relative_uri }}/" title="API Enhancement Proposals">
               <div class="glue-header__logo-container">
                 <svg role="img" aria-hidden="true" class="glue-header__logo-svg">
                 <!--<use xlink:href="{{ site.relative_uri }}/assets/images/glue-icons.svg#google-color-logo"></use>-->


### PR DESCRIPTION
Now when you hover over the AEP name/logo, it will read "Home" instead of "Google"