### PR TITLE
fix: degoogle homepage

### DIFF
--- a/aep_site/support/templates/index.html.j2
+++ b/aep_site/support/templates/index.html.j2
@@ -27,9 +27,8 @@
   <div class="aep-landing-content">
     <h1>Welcome</h1>
     <p>
-      AEPs are design documents that summarize Google's API design
-      decisions. They also provide a framework and system for others to
-      document their own API design rules and practices.
+      AEPs are documents that collectively form an API design specification as
+      well as explain the design choices of the specification.
     </p>
   </div>
 

--- a/tests/test_data/config/hero.yaml
+++ b/tests/test_data/config/hero.yaml
@@ -23,8 +23,8 @@ shortcuts:
       text: Contribute to the project
   - title: Want to use AEPs for your organization?
     description: |
-      AEPs are designed to be useful outside of Google. Take a look at how you
-      might choose which AEPs are best suited to your API design needs.
+      AEPs are designed to be useful for any organization. Take a look at how
+      you might choose which AEPs are best suited to your API design needs.
     button:
       href: /adopting
       text: Learn more


### PR DESCRIPTION
The homepage still contains some Google-related
wording.