### PR TITLE
use GA tag from site config

### DIFF
--- a/aep_site/support/templates/layouts/base.html.j2
+++ b/aep_site/support/templates/layouts/base.html.j2
@@ -25,19 +25,24 @@
     {% block js -%}
     {% endblock -%}
     {# {% seo %} -- port this #}
+    {% if site.config.site.ga_tag %}
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NSXMVSDN');</script>
+    })(window,document,'script','dataLayer','{{ site.config.site.ga_tag }}');</script>
     <!-- End Google Tag Manager -->
+    {% endif %}
   </head>
   <body>
+
+  {% if site.config.site.ga_tag %}
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NSXMVSDN"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.config.site.ga_tag }}"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
+    {% endif  %}
     {% include 'includes/header.html.j2' %}
     <div class="glue-page">
       {% block main %}

--- a/tests/test_data/config/site.yaml
+++ b/tests/test_data/config/site.yaml
@@ -1,0 +1,1 @@
+ga_tag: testtag


### PR DESCRIPTION
Addresses #14 

This fetches a Google Analytics tag from a config file in aep.dev

https://github.com/aep-dev/aep.dev/pull/154 should be merged along with this change.