### PR TITLE
feat: Enable anchorlink in TOC extension to headers to link to themselves

### DIFF
--- a/aep_site/md.py
+++ b/aep_site/md.py
@@ -32,6 +32,7 @@ class MarkdownDocument(str):
                 "toc": {
                     "title": toc_title,
                     "toc_depth": "2-3",
+                    "anchorlink": True,
                 },
             },
             tab_length=2,


### PR DESCRIPTION
https://python-markdown.github.io/extensions/toc/#usage

![anchor](https://github.com/aep-dev/site-generator/assets/41777/da605969-9a6a-4930-b279-fb9264579b3d)

